### PR TITLE
fix ‑‑auto-abstract spacing example

### DIFF
--- a/src/AutoAbstractOption.asciidoc
+++ b/src/AutoAbstractOption.asciidoc
@@ -64,6 +64,7 @@ empty line between abstract description and the rest here):
 ----
 type
   { Short description of this class.
+    
     More elaborate description of this class. }
   TMyClass = class
   ...


### PR DESCRIPTION
Preceding paragraph mentions an extra blank line, but this line is not inserted. Presumably, copy/paste mistake.